### PR TITLE
fix function return values

### DIFF
--- a/src/ofxNetworkSyncClient.cpp
+++ b/src/ofxNetworkSyncClient.cpp
@@ -37,7 +37,7 @@ bool ofxNetworkSyncClient::close(){
 	ofLogVerbose("ofxNetworkSyncClient") << "Close connection";
 	if(isThreadRunning()){
 		stopThread();
-		waitForThread(1000, true);
+		waitForThread();
 	}
 	if(client.isConnected()){
 		return client.close();

--- a/src/ofxNetworkSyncClient.cpp
+++ b/src/ofxNetworkSyncClient.cpp
@@ -130,10 +130,10 @@ void ofxNetworkSyncClient::onMessageReceived(string & message){
 
 
 int ofxNetworkSyncClient::getRemotePort(){
-	client.getPort();
+	return client.getPort();
 }
 string ofxNetworkSyncClient::getRemoteHost(){
-	client.getIP();
+	return client.getIP();
 }
 
 

--- a/src/ofxNetworkSyncClientState.cpp
+++ b/src/ofxNetworkSyncClientState.cpp
@@ -42,7 +42,7 @@ void ofxNetworkSyncClientState::stopCalibration(){
 }
 
 
-bool ofxNetworkSyncClientState::close(){
+void ofxNetworkSyncClientState::close(){
 	if(isThreadRunning()){
 		stopThread();
 		waitForThread();

--- a/src/ofxNetworkSyncClientState.cpp
+++ b/src/ofxNetworkSyncClientState.cpp
@@ -14,6 +14,8 @@ ofxNetworkSyncClientState::ofxNetworkSyncClientState(ofxNetworkSyncServer * _ser
 	port = tcpServer->getClientPort(clientId);
 	
 	ofAddListener(messageReceived, this, &ofxNetworkSyncClientState::onMessageReceived);
+	//ofAddListener(clientDisconnected, this, &ofxNetworkSyncClientState::onClientDisconnect);
+	
 	ofLogVerbose("ofxNetworkSyncClientState") << "Client state created. send client id to client and start thread";
 	send(MESSAGE_HEADER_CLIENT_ID+MESSAGE_HEADER_SEPARATOR+ofToString(clientId));
 	step = WAIT;
@@ -90,6 +92,9 @@ void ofxNetworkSyncClientState::onMessageReceived(string & message){
 	}
 }
 
+void ofxNetworkSyncClientState::onClientDisconnect(int clientId) {
+	ofLogVerbose("ofxNetworkSyncClientState#" + ofToString(clientId)) << " disconnected";
+}
 
 
 bool ofxNetworkSyncClientState::isConnected(){

--- a/src/ofxNetworkSyncClientState.h
+++ b/src/ofxNetworkSyncClientState.h
@@ -53,6 +53,8 @@ public:
 	
 protected:
 	void threadedFunction();
-	void onMessageReceived(string & message);};
+	void onMessageReceived(string & message);
+	void onClientDisconnect(int clientId); 
+};
 
 #endif

--- a/src/ofxNetworkSyncClientState.h
+++ b/src/ofxNetworkSyncClientState.h
@@ -40,7 +40,7 @@ public:
 
 	void startCalibration();
 	void stopCalibration();
-	bool close();
+	void close();
 	void send(string message);
 	
 	bool isConnected();


### PR DESCRIPTION
Visual Studio c++ compiler dont accept defined return value without really
return a value.
